### PR TITLE
fix: Request parse bug + get tests running on Python 3.8.

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,27 @@
+on:
+  # Trigger during pull requests and merge to master.
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.8'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+    - name: Lint with Ruff
+      run: |
+        pip install ruff
+        ruff --output-format=github .
+      continue-on-error: true

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,3 +1,5 @@
+name: Ruff
+
 on:
   # Trigger during pull requests and merge to master.
   pull_request:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,13 @@
 name: Python package
 
-on: [push]
+on:
+  # Trigger during pull requests and merge to master.
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,22 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python: ["3.8"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install tox and any other packages
+        run: pip install tox
+      - name: Run tox
+        # Run tox using the version of Python in `PATH`.
+        run: tox -e py

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Python package
+name: Tests
 
 on:
   # Trigger during pull requests and merge to master.

--- a/authorize/__init__.py
+++ b/authorize/__init__.py
@@ -1,3 +1,5 @@
+# ruff: noqa
+
 """
 Authorize.net payment gateway interface.
 

--- a/authorize/apis/customer.py
+++ b/authorize/apis/customer.py
@@ -1,5 +1,5 @@
-from decimal import Decimal
 import urllib
+from decimal import Decimal
 from urllib.parse import urlencode
 
 from suds import WebFault
@@ -7,7 +7,6 @@ from suds.client import Client
 
 from authorize.apis.transaction import parse_response
 from authorize.exceptions import AuthorizeConnectionError, AuthorizeResponseError
-
 
 PROD_URL = "https://api.authorize.net/soap/v1/Service.asmx?WSDL"
 TEST_URL = "https://apitest.authorize.net/soap/v1/Service.asmx?WSDL"
@@ -104,6 +103,8 @@ class CustomerAPI(object):
         payment_profile.payment = payment_type
 
         # Customer billing name and address are optional fields
+        if payment_profile.billTo is None:
+            payment_profile.billTo = self.client.factory.create("CustomerAddressType")
         if credit_card.first_name:
             payment_profile.billTo.firstName = credit_card.first_name
         if credit_card.last_name:

--- a/authorize/apis/customer.py
+++ b/authorize/apis/customer.py
@@ -1,4 +1,3 @@
-import urllib
 from decimal import Decimal
 from urllib.parse import urlencode
 
@@ -46,7 +45,7 @@ class CustomerAPI(object):
         method = getattr(self.client.service, service)
         try:
             response = method(self.client_auth, *args)
-        except WebFault as e:
+        except WebFault:
             raise AuthorizeConnectionError("Error contacting SOAP API.")
         if response.resultCode != "Ok":
             error = response.messages[0][0]

--- a/authorize/apis/transaction_detail.py
+++ b/authorize/apis/transaction_detail.py
@@ -1,4 +1,3 @@
-from decimal import Decimal
 from urllib.parse import urlencode
 
 from suds import WebFault
@@ -44,7 +43,7 @@ class TransactionDetailAPI(object):
         method = getattr(self.client.service, service)
         try:
             response = method(self.client_auth, *args)
-        except WebFault as e:
+        except WebFault:
             raise AuthorizeConnectionError("Error contacting SOAP API.")
         if response.resultCode != "Ok":
             error = response.messages[0][0]

--- a/authorize/client.py
+++ b/authorize/client.py
@@ -17,11 +17,12 @@ Authorize.net_.
 
 """
 
+from uuid import uuid4
+
 from authorize.apis.customer import CustomerAPI
 from authorize.apis.recurring import RecurringAPI
 from authorize.apis.transaction import TransactionAPI
 from authorize.apis.transaction_detail import TransactionDetailAPI
-from uuid import uuid4
 
 
 class AuthorizeClient(object):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,8 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os
+import sys
+import os
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-suds==0.4
+suds==1.1.2
 mock==0.8.0
-unittest2==0.5.1
 sphinx==1.1.3
 requests==2.32.3
 urllib3==2.2.1
+responses==0.25.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 suds==1.1.2
 mock==0.8.0
-sphinx==1.1.3
 requests==2.32.3
 urllib3==2.2.1
 responses==0.25.3

--- a/setup.py
+++ b/setup.py
@@ -54,15 +54,14 @@ from setuptools import setup
 setup(
     name="AuthorizeSauce",
     version="0.2.1",
-    author="Jeff Schenck",
-    author_email="jmschenck@gmail.com",
+    author="TeamUp",
     url="http://authorize-sauce.readthedocs.org/",
-    download_url="https://github.com/jeffschenck/authorizesauce",
+    download_url="https://github.com/goteamup/authorizesauce",
     description="An awesome-sauce Python library for accessing the Authorize.net API. Sweet!",
     long_description=__doc__,
     license="MIT",
     install_requires=[
-        "suds-community==1.1.2",
+        "suds==1.1.2",
         "requests",
         "urllib3"
     ],

--- a/tests/test_api_customer.py
+++ b/tests/test_api_customer.py
@@ -1,10 +1,10 @@
 from datetime import date
+from unittest import TestCase
 
 import mock
 from suds import WebFault
-from unittest import TestCase
 
-from authorize.apis.customer import CustomerAPI, PROD_URL, TEST_URL
+from authorize.apis.customer import PROD_URL, TEST_URL, CustomerAPI
 from authorize.data import Address, CreditCard
 from authorize.exceptions import AuthorizeConnectionError, AuthorizeResponseError
 
@@ -86,7 +86,7 @@ class CustomerAPITests(TestCase):
         self.Client.reset_mock()
         api = CustomerAPI("123", "456")
         self.assertEqual(self.Client.call_args, None)
-        client_ = api.client
+        api.client
         self.assertEqual(self.Client.call_args[0][0], TEST_URL)
         client_auth = api.client_auth
         self.assertEqual(client_auth.name, "123")

--- a/tests/test_api_recurring.py
+++ b/tests/test_api_recurring.py
@@ -1,10 +1,10 @@
 from datetime import date, timedelta
+from unittest import TestCase
 
 import mock
 from suds import WebFault
-from unittest import TestCase
 
-from authorize.apis.recurring import PROD_URL, RecurringAPI, TEST_URL
+from authorize.apis.recurring import PROD_URL, TEST_URL, RecurringAPI
 from authorize.data import CreditCard
 from authorize.exceptions import (
     AuthorizeConnectionError,
@@ -69,7 +69,7 @@ class RecurringAPITests(TestCase):
         self.Client.reset_mock()
         api = RecurringAPI("123", "456")
         self.assertEqual(self.Client.call_args, None)
-        client_ = api.client
+        api.client
         self.assertEqual(self.Client.call_args[0][0], TEST_URL)
         client_auth = api.client_auth
         self.assertEqual(client_auth.name, "123")

--- a/tests/test_live.py
+++ b/tests/test_live.py
@@ -2,15 +2,13 @@
 Tests against the sandbox Authorize.net API. Slow, requires internet.
 """
 
-from datetime import date, timedelta
 import os
 import random
-
-from unittest import skipUnless, TestCase
+from datetime import date, timedelta
+from unittest import TestCase, skipUnless
 
 from authorize import Address, AuthorizeClient, CreditCard
 from authorize.exceptions import AuthorizeResponseError
-
 
 # Authorize.net developer login for test (https://test.authorize.net)
 # user: authorizepy0
@@ -18,11 +16,10 @@ from authorize.exceptions import AuthorizeResponseError
 # gateway id: 355553
 
 SKIP_MESSAGE = (
-    "Live tests only run if the AUTHORIZE_LIVE_TESTS " "environment variable is true."
+    "Live tests only run if the AUTHORIZE_LIVE_TESTS environment variable is true."
 )
 TEST_LOGIN_ID = "285tUPuS"
 TEST_TRANSACTION_KEY = "58JKJ4T95uee75wd"
-
 
 @skipUnless(os.environ.get("AUTHORIZE_LIVE_TESTS"), SKIP_MESSAGE)
 class AuthorizeLiveTests(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,3 @@
-[tox]
-envlist = py3
-
 [testenv]
 deps =
     -r requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py3
+
+[testenv]
+deps =
+    -r requirements.txt
+setenv =
+    AUTHORIZE_LIVE_TESTS = 1
+commands = 
+    # Run unittests.
+    python -m unittest discover -s tests -v


### PR DESCRIPTION
- Fix handling of response parsing.
- Get tests up and running. 
  - They are all functionally the same.
  - Changed some mocking for requests (used the responses library).
  - Minor tweaks such as sorting body params - since explicit order doesn't matter
- Tests uncovered situations where there were missing nested SOAP objects, so I had to add some calls to create them if they were `None.`